### PR TITLE
Fix/ld runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The output .json file will be saved in `examples/ahs_program.json`.
 1.B Generate .json using Python Braket SDK from the AHS program object:
 ```
 ahs_ir = ahs_program.to_ir()
-json_object = json.loads(ahs_ir.json())
+json_data = json.loads(ahs_ir.json())
 json_string = json.dumps(json_data, indent=4) 
 filename = "ahs_program.json"
 with open(filename, "w") as json_file:

--- a/src/mps_runner.jl
+++ b/src/mps_runner.jl
@@ -44,10 +44,10 @@ function parse_commandline()
         "--compute-truncation-error"
             help = "whether to compute the error induced by truncation at each step (computationally expensive)"
             action = :store_true # default without this flag is false
-        "--tau"
-            help = "time evolution step size in seconds"
-            arg_type = Float64
-            default = 0.01e-6
+        # "--tau"
+        #     help = "time evolution step size in seconds"
+        #     arg_type = Float64
+        #     default = 0.01e-6
         "--n-tau-steps"
             help = "number of time evolution steps to simulate"
             arg_type = Int


### PR DESCRIPTION
*Issue #, if available:*

1. Program with empty local detuning will throw an error
2. Program with max time not equal to 4 us will throw an error

*Description of changes:*

1. modify parse_protocol so that programs without local detuning can be run
2. deprecate tau and use n-tau-steps and the time max in the program to determine the trotter time step


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
