### PR TITLE
Make shifting Fields or local Detunings optional. Add tests.

### DIFF
--- a/src/mps_utils.jl
+++ b/src/mps_utils.jl
@@ -57,16 +57,16 @@ function parse_protocol(ahs_program, τ::Float64, n_τ_steps::Int)
     values_Ω = ahs_program["hamiltonian"]["drivingFields"][1]["amplitude"]["time_series"]["values"]
         
     n_atoms = length(ahs_program["setup"]["ahs_register"]["sites"])
+
     # Supporting both localDetuning and shiftingFields naming conventions
-    loc_detuning_key = ""
-    if "shiftingFields" ∈ keys(ahs_program["hamiltonian"])
-        loc_detuning_key = "shiftingFields"
+    loc_detuning_key = if "shiftingFields" ∈ keys(ahs_program["hamiltonian"])
+        "shiftingFields"
     elseif "localDetuning" ∈ keys(ahs_program["hamiltonian"])
-        loc_detuning_key = "localDetuning"
+        "localDetuning"
     end
     
     # Check if local detuning or shifting fields were found, otherwise assign zeros
-    if !isempty(loc_detuning_key)
+    if !(loc_detuning_key === nothing)
         values_local_detuning = ahs_program["hamiltonian"][loc_detuning_key][1]["magnitude"]["time_series"]["values"]
         time_points_loc_detuning = ahs_program["hamiltonian"][loc_detuning_key][1]["magnitude"]["time_series"]["times"]
         pattern = ahs_program["hamiltonian"][loc_detuning_key][1]["magnitude"]["pattern"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,8 +3,6 @@ using Test
 using JSON3
 
 @testset "BraketAHS.jl: Non-empty local detunings" begin
-    # Write your tests here.
-
     json_str = """{"setup":{"ahs_register":{"sites":[["0.0","0.0"],["5.499999999999999856993733449161965e-6","0.0"],["0.0","5.499999999999999856993733449161965e-6"],["5.499999999999999856993733449161965e-6","5.499999999999999856993733449161965e-6"]],"filling":[1,1,1,1]}},"braketSchemaHeader":{"name":"braket.ir.ahs.program","version":"1"},"hamiltonian":{"shiftingFields":[{"magnitude":{"pattern":["0.0","0.0","0.0","0.0"],"time_series":{"values":["0.0","0.0"],"times":["0.0","3.999999999999999818992447303545035e-6"]}}}],"drivingFields":[{"phase":{"pattern":"uniform","time_series":{"values":["0.0","0.0"],"times":["0.0","3.999999999999999818992447303545035e-6"]}},"detuning":{"pattern":"uniform","time_series":{"values":["-3.15e7","-3.15e7","3.15e7","3.15e7"],"times":["0.0","9.999999999999999547481118258862587e-8","3.899999999999999929396754527743951e-6","3.999999999999999818992447303545035e-6"]}},"amplitude":{"pattern":"uniform","time_series":{"values":["0.0","6.3e6","6.3e6","0.0"],"times":["0.0","9.999999999999999547481118258862587e-8","3.899999999999999929396754527743951e-6","3.999999999999999818992447303545035e-6"]}}}]}}
     """
     ahs_json = JSON3.read(json_str)
@@ -30,8 +28,6 @@ using JSON3
     mps_density = result["density"][:, end]
     expected_density = [0.49558400861051327,0.4955839949350386,0.49558370707943783,0.49558323080865946]
     @test isapprox(mps_density, expected_density; atol=1e-7)
-    # add apprx cmoparison isapprox(array1, array2; atol=tolerance)
-
 end
 
 @testset "BraketAHS.jl: Empty local detunings" begin
@@ -60,6 +56,4 @@ end
     mps_density = result["density"][:, end]
     expected_density = [0.49558400861051327,0.4955839949350386,0.49558370707943783,0.49558323080865946]
     @test isapprox(mps_density, expected_density; atol=1e-7)
-    # add apprx cmoparison isapprox(array1, array2; atol=tolerance)
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using BraketAHS: run, save_results
 using Test
 using JSON3
 
-@testset "BraketAHS.jl" begin
+@testset "BraketAHS.jl: Non-empty local detunings" begin
     # Write your tests here.
 
     json_str = """{"setup":{"ahs_register":{"sites":[["0.0","0.0"],["5.499999999999999856993733449161965e-6","0.0"],["0.0","5.499999999999999856993733449161965e-6"],["5.499999999999999856993733449161965e-6","5.499999999999999856993733449161965e-6"]],"filling":[1,1,1,1]}},"braketSchemaHeader":{"name":"braket.ir.ahs.program","version":"1"},"hamiltonian":{"shiftingFields":[{"magnitude":{"pattern":["0.0","0.0","0.0","0.0"],"time_series":{"values":["0.0","0.0"],"times":["0.0","3.999999999999999818992447303545035e-6"]}}}],"drivingFields":[{"phase":{"pattern":"uniform","time_series":{"values":["0.0","0.0"],"times":["0.0","3.999999999999999818992447303545035e-6"]}},"detuning":{"pattern":"uniform","time_series":{"values":["-3.15e7","-3.15e7","3.15e7","3.15e7"],"times":["0.0","9.999999999999999547481118258862587e-8","3.899999999999999929396754527743951e-6","3.999999999999999818992447303545035e-6"]}},"amplitude":{"pattern":"uniform","time_series":{"values":["0.0","6.3e6","6.3e6","0.0"],"times":["0.0","9.999999999999999547481118258862587e-8","3.899999999999999929396754527743951e-6","3.999999999999999818992447303545035e-6"]}}}]}}
@@ -31,4 +31,35 @@ using JSON3
     expected_density = [0.49558400861051327,0.4955839949350386,0.49558370707943783,0.49558323080865946]
     @test isapprox(mps_density, expected_density; atol=1e-7)
     # add apprx cmoparison isapprox(array1, array2; atol=tolerance)
+
+end
+
+@testset "BraketAHS.jl: Empty local detunings" begin
+    json_str = """{"setup":{"ahs_register":{"sites":[["0.0","0.0"],["5.499999999999999856993733449161965e-6","0.0"],["0.0","5.499999999999999856993733449161965e-6"],["5.499999999999999856993733449161965e-6","5.499999999999999856993733449161965e-6"]],"filling":[1,1,1,1]}},"braketSchemaHeader":{"name":"braket.ir.ahs.program","version":"1"},"hamiltonian":{"drivingFields":[{"phase":{"pattern":"uniform","time_series":{"values":["0.0","0.0"],"times":["0.0","3.999999999999999818992447303545035e-6"]}},"detuning":{"pattern":"uniform","time_series":{"values":["-3.15e7","-3.15e7","3.15e7","3.15e7"],"times":["0.0","9.999999999999999547481118258862587e-8","3.899999999999999929396754527743951e-6","3.999999999999999818992447303545035e-6"]}},"amplitude":{"pattern":"uniform","time_series":{"values":["0.0","6.3e6","6.3e6","0.0"],"times":["0.0","9.999999999999999547481118258862587e-8","3.899999999999999929396754527743951e-6","3.999999999999999818992447303545035e-6"]}}}]}}
+    """
+    ahs_json = JSON3.read(json_str)
+
+    args = Dict(
+        "experiment-path" => "test/",
+        "program-path" => "",
+        "interaction-radius" => 7e-6,
+        "cutoff" => 1e-7,
+        "shots" => 1000,
+        "max-bond-dim" => 16,
+        "compute-truncation-error" => false,
+        "tau" => 0.01e-6,        
+        "n-tau-steps" => 400,
+        "C6" => 5.42e-24,
+        "compute-correlators" => false,
+        "compute-energies" => false,
+        "generate-plots" => false
+    )
+
+    result = run(ahs_json, args)
+
+    mps_density = result["density"][:, end]
+    expected_density = [0.49558400861051327,0.4955839949350386,0.49558370707943783,0.49558323080865946]
+    @test isapprox(mps_density, expected_density; atol=1e-7)
+    # add apprx cmoparison isapprox(array1, array2; atol=tolerance)
+
 end


### PR DESCRIPTION
*Resolving Issue #22 *

*Description of changes:*
 - Support both `localDetuning` and `shiftingFields` as input fields in AHS program JSON.
 - Make these fields optional (ignore if not present in AHS JSON)
 - Add test for empty `localDetuning` or `shiftingFields` field